### PR TITLE
feat(db): initialize PostgreSQL and Redis integration

### DIFF
--- a/app/db/base.py
+++ b/app/db/base.py
@@ -1,0 +1,6 @@
+from sqlalchemy.orm import declarative_base
+
+# Base class for all ORM models.
+# All mapped classes must inherit from this, so that
+# SQLAlchemy collects their metadata in one place.
+Base = declarative_base()

--- a/app/db/redis.py
+++ b/app/db/redis.py
@@ -1,0 +1,26 @@
+from typing import AsyncGenerator
+
+import aioredis
+
+from app.core.config import settings
+
+# Create a global Redis client instance.
+# decode_responses=True to get Python strings instead of bytes.
+redis_client = aioredis.from_url(
+    settings.REDIS_URL,
+    encoding="utf-8",
+    decode_responses=True,
+)
+
+
+async def get_redis() -> AsyncGenerator[aioredis.Redis, None]:
+    """
+    FastAPI dependency that yields a Redis client.
+
+    Yields:
+        aioredis.Redis: shared Redis connection.
+
+    Since aioredis maintains its own connection pool internally,
+    we simply yield the singleton instance.
+    """
+    yield redis_client

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -1,0 +1,33 @@
+from typing import AsyncGenerator
+
+from sqlalchemy.ext.asyncio import async_sessionmaker  # new in SQLAlchemy 2.0
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+
+from app.core.config import settings
+
+# Create async engine for PostgreSQL (using asyncpg driver)
+engine = create_async_engine(
+    settings.DATABASE_URL,
+    echo=False,
+    future=True,
+)
+
+# Create an async session factory
+# async_sessionmaker is designed for AsyncSession + AsyncEngine
+AsyncSessionLocal = async_sessionmaker(
+    engine,
+    expire_on_commit=False,  # objects won't be expired after commit
+    class_=AsyncSession,
+)
+
+
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    """
+    FastAPI dependency that yields an AsyncSession.
+    Ensures that session is closed after request.
+
+    Yields:
+        AsyncSession: async session bound to the engine
+    """
+    async with AsyncSessionLocal() as session:
+        yield session

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 alembic==1.15.2
+aioredis==2.0.1
 annotated-types==0.7.0
 anyio==4.9.0
 async-timeout==5.0.1


### PR DESCRIPTION
This PR introduces the new `app/db` module to streamline database and cache integrations:

1. **base.py**
   - Defines a single `Base = declarative_base()` class for all ORM models.
   - Consolidates metadata collection to support Alembic migrations out of the box.

2. **session.py**
   - Creates an asynchronous engine using `create_async_engine(settings.DATABASE_URL)`.
   - Utilizes `async_sessionmaker` to produce `AsyncSession` instances.
   - Implements the FastAPI dependency `get_db()`, which yields an `AsyncSession` within an `async with` context and ensures proper cleanup after each request.

3. **redis.py**
   - Initializes a global `aioredis` client based on `settings.REDIS_URL`.
   - Provides the FastAPI dependency `get_redis()`, allowing services and routers to inject a ready-to-use Redis client.