### PR TITLE
chore(ci-cd): initial setup of CI/CD pipeline for lint, test, build & publish

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI/CD
 
 on:
   push:
@@ -13,7 +13,6 @@ jobs:
   lint:
     name: Lint & Format
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -41,7 +40,6 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     needs: lint
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -58,3 +56,34 @@ jobs:
 
       - name: Run pytest
         run: pytest --maxfail=1 --disable-warnings -q
+
+  build-and-push:
+    name: Build & Push Docker Image
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/event-manager-api:latest
+            ghcr.io/${{ github.repository_owner }}/event-manager-api:${{ github.sha }}
+

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_PAT }}
 
       - name: Build and push
         uses: docker/build-push-action@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Stage 1: install dependencies in a slim builder image
+FROM python:3.10-slim-bullseye AS builder
+
+WORKDIR /app
+
+# Copy and install runtime dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code (optional for wheels; здесь для completeness)
+COPY . .
+
+# Stage 2: runtime image
+FROM python:3.10-slim-bullseye
+
+WORKDIR /app
+
+# Copy entire /usr/local (bin + lib) from the builder
+COPY --from=builder /usr/local /usr/local
+
+# Copy application code
+COPY --from=builder /app /app
+
+# Expose FastAPI port
+EXPOSE 8000
+
+# Launch FastAPI via Uvicorn
+ENTRYPOINT ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,31 @@
+# app/main.py
+
+from fastapi import FastAPI
+
+from app.core.logging import init_logging
+
+
+def create_app() -> FastAPI:
+    """
+    Create and configure FastAPI application instance.
+    """
+    init_logging()
+    app = FastAPI(
+        title="NeoFi Event Manager API",
+        version="0.1.0",
+        docs_url="/docs",
+        redoc_url="/redoc",
+        openapi_url="/openapi.json",
+    )
+
+    @app.get("/health", tags=["Health"])
+    async def health_check() -> dict:
+        """
+        Health check endpoint.
+        """
+        return {"status": "ok"}
+
+    return app
+
+
+app = create_app()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  api:
+    build: .
+    # Explicit container name for the API service
+    container_name: event-manager-api
+    ports:
+      - "8000:8000"
+    env_file: .env
+    depends_on:
+      - db
+      - redis
+
+  db:
+    image: postgres:latest
+    # Explicit container name for the Postgres database
+    container_name: event-manager-db
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    ports:
+      - "5432:5432"
+
+  redis:
+    image: redis:latest
+    # Explicit container name for the Redis cache
+    container_name: event-manager-redis
+    ports:
+      - "6379:6379"


### PR DESCRIPTION
This PR establishes the CI/CD pipeline for the project, covering:

1. **Lint & Format**  
   - Runs Black, isort, and flake8.

2. **Test**  
   - Installs dependencies and executes pytest (initial smoke test).

3. **Build & Publish**  
   - Builds the Docker image using Buildx and QEMU.
   - Authenticates to GitHub Container Registry with `GHCR_PAT`.
   - Pushes the image tagged as `latest` and by commit SHA.

**What’s not included:**  
- There is no automatic deployment step. This pipeline only produces and publishes the Docker artifact.