### PR TITLE
Add event history versioning and diff support with jsondiff

### DIFF
--- a/app/api/history.py
+++ b/app/api/history.py
@@ -1,0 +1,107 @@
+import logging
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_db
+from app.schemas.event import EventRead
+from app.schemas.history import HistoryRead
+from app.services.event_service import get_event
+from app.services.history_service import (
+    get_diff_between_versions,
+    get_event_history_versions,
+    get_event_version,
+    rollback_event_to_version,
+)
+from app.utils.deps import get_current_user
+
+router = APIRouter(prefix="/api/events", tags=["events"])
+
+logger = logging.getLogger(__name__)
+audit_logger = logging.getLogger("audit")
+
+
+@router.get("/{event_id}/history", response_model=List[HistoryRead])
+async def get_history(
+    event_id: UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    """Retrieve all history versions of the event."""
+    await get_event(db, current_user.id, event_id)
+    versions = await get_event_history_versions(db, event_id)
+    logger.info(
+        "User %s fetched history list for event %s", current_user.username, event_id
+    )
+    return versions
+
+
+@router.get("/{event_id}/history/{version_id}", response_model=HistoryRead)
+async def get_version(
+    event_id: UUID,
+    version_id: UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    """Retrieve a specific history version by ID."""
+    await get_event(db, current_user.id, event_id)
+    version = await get_event_version(db, version_id)
+    if not version:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Version not found"
+        )
+    logger.info(
+        "User %s fetched history version %s for event %s",
+        current_user.username,
+        version_id,
+        event_id,
+    )
+    return version
+
+
+@router.post("/{event_id}/rollback/{version_id}", response_model=EventRead)
+async def rollback_version(
+    event_id: UUID,
+    version_id: UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    """Rollback event to a previous version."""
+    await get_event(db, current_user.id, event_id)
+    event = await rollback_event_to_version(db, event_id, version_id, current_user.id)
+    logger.info(
+        "User %s rolled back event %s to version %s",
+        current_user.username,
+        event_id,
+        version_id,
+    )
+    audit_logger.info(
+        "Rollback event: user=%s event=%s version=%s",
+        current_user.id,
+        event_id,
+        version_id,
+    )
+    return EventRead.from_orm(event)
+
+
+@router.get("/{event_id}/diff/{version_id1}/{version_id2}")
+async def diff_versions(
+    event_id: UUID,
+    version_id1: UUID,
+    version_id2: UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    """Get a diff between two history versions."""
+    await get_event(db, current_user.id, event_id)
+    diff = await get_diff_between_versions(db, version_id1, version_id2)
+    logger.info(
+        "User %s requested diff between versions %s and %s for event %s",
+        current_user.username,
+        version_id1,
+        version_id2,
+        event_id,
+    )
+    return diff

--- a/app/main.py
+++ b/app/main.py
@@ -19,6 +19,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 from app.api.auth import router as auth_router
 from app.api.events import router as events_router
+from app.api.history import router as history_router
 from app.api.permissions import router as permissions_router
 from app.api.ws_notifications import redis_listener
 from app.api.ws_notifications import router as ws_notifications_router
@@ -254,6 +255,7 @@ def create_app() -> FastAPI:
     app.include_router(events_router)
     app.include_router(permissions_router)
     app.include_router(ws_notifications_router)
+    app.include_router(history_router)
 
     return app
 

--- a/app/models/history.py
+++ b/app/models/history.py
@@ -1,3 +1,5 @@
+# app/models/history.py
+
 import uuid
 from datetime import datetime
 
@@ -11,36 +13,40 @@ from app.db.base import Base
 
 class History(Base):
     """
-    ORM model for storing event version snapshots.
+    ORM model for storing event version snapshots with attribution.
+
+    Each record stores a snapshot of an Event's data at a given version,
+    who made the change, and when.
     """
 
     __tablename__ = "histories"
 
-    # Primary key
+    # Unique UUID primary key for the history entry
     id: Mapped[uuid.UUID] = mapped_column(
         PG_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
     )
 
-    # Foreign key to the event
+    # Foreign key to the original event
     event_id: Mapped[uuid.UUID] = mapped_column(
         PG_UUID(as_uuid=True),
         ForeignKey("events.id", ondelete="CASCADE"),
         nullable=False,
+        index=True,
     )
     event = relationship("Event", back_populates="histories")
 
-    # Incremental version number
+    # Sequential version number per event (starting at 1)
     version: Mapped[int] = mapped_column(Integer, nullable=False)
 
-    # JSONB snapshot of all event fields
+    # JSONB snapshot storing full event data as dict
     data: Mapped[dict] = mapped_column(JSONB, nullable=False)
 
-    # Timestamp of change
+    # Timestamp when this version was created
     timestamp: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+        DateTime(timezone=True), nullable=False, default=datetime.utcnow
     )
 
-    # Who made the change
+    # User who made the change, can be NULL if user deleted
     changed_by: Mapped[uuid.UUID | None] = mapped_column(
         PG_UUID(as_uuid=True),
         ForeignKey("users.id", ondelete="SET NULL"),

--- a/app/schemas/history.py
+++ b/app/schemas/history.py
@@ -1,0 +1,25 @@
+# app/schemas/history.py
+
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class HistoryRead(BaseModel):
+    """
+    Response model for a single history version of an event.
+    """
+
+    id: UUID = Field(..., description="Unique ID of the history record")
+    event_id: UUID = Field(..., description="ID of the event")
+    version: int = Field(..., description="Sequential version number of the event")
+    data: dict = Field(..., description="Snapshot of the event data at this version")
+    timestamp: datetime = Field(..., description="When this version was created")
+    changed_by: Optional[UUID] = Field(
+        None, description="User ID who made the change (may be null)"
+    )
+
+    class Config:
+        orm_mode = True

--- a/app/services/history_service.py
+++ b/app/services/history_service.py
@@ -1,0 +1,195 @@
+# app/services/history_service.py
+
+import logging
+from datetime import datetime
+from typing import List, Optional
+from uuid import UUID
+
+import jsondiff
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.event import Event
+from app.models.history import History
+from app.utils.exceptions import NotFoundError, ServiceUnavailableError
+
+logger = logging.getLogger(__name__)
+audit_logger = logging.getLogger("audit")
+
+
+async def get_event_history_versions(db: AsyncSession, event_id: UUID) -> List[History]:
+    """
+    Retrieve all history versions for the specified event ordered by version ascending.
+    """
+    try:
+        stmt = (
+            select(History)
+            .where(History.event_id == event_id)
+            .order_by(History.version)
+        )
+        result = await db.execute(stmt)
+        return list(result.scalars().all())
+    except Exception as exc:
+        logger.error(
+            "Error fetching history versions for event %s: %s",
+            event_id,
+            exc,
+            exc_info=True,
+        )
+        raise ServiceUnavailableError("Database temporarily unavailable")
+
+
+async def get_event_version(db: AsyncSession, version_id: UUID) -> Optional[History]:
+    """
+    Retrieve a specific history version by its ID.
+    """
+    try:
+        stmt = select(History).where(History.id == version_id)
+        result = await db.execute(stmt)
+        return result.scalars().first()
+    except Exception as exc:
+        logger.error(
+            "Error fetching history version %s: %s", version_id, exc, exc_info=True
+        )
+        raise ServiceUnavailableError("Database temporarily unavailable")
+
+
+async def rollback_event_to_version(
+    db: AsyncSession, event_id: UUID, version_id: UUID, user_id: UUID
+) -> Event:
+    """
+    Roll back an event to a specified history version.
+    Also saves the current event state as a new history version before rollback.
+    """
+    try:
+        version = await get_event_version(db, version_id)
+        if not version:
+            logger.warning("Rollback failed: version %s not found", version_id)
+            raise NotFoundError("Version not found")
+
+        stmt = select(Event).where(Event.id == event_id)
+        result = await db.execute(stmt)
+        event = result.scalars().first()
+        if not event:
+            logger.warning("Rollback failed: event %s not found", event_id)
+            raise NotFoundError("Event not found")
+
+        # Apply the snapshot data to the event
+        data = version.data
+        for field in [
+            "title",
+            "description",
+            "start_time",
+            "end_time",
+            "location",
+            "is_recurring",
+            "recurrence_pattern",
+        ]:
+            value = data.get(field)
+            if value is not None:
+                # Convert ISO string back to datetime if necessary
+                if field in ("start_time", "end_time") and isinstance(value, str):
+                    value = datetime.fromisoformat(value)
+                setattr(event, field, value)
+
+        # Determine next version number for history
+        version_stmt = (
+            select(History.version)
+            .where(History.event_id == event_id)
+            .order_by(History.version.desc())
+            .limit(1)
+        )
+        last_version_result = await db.execute(version_stmt)
+        last_version = last_version_result.scalars().first()
+        next_version = 1 if last_version is None else last_version + 1
+
+        # Create a snapshot of current event state
+        current_snapshot = {
+            "title": event.title,
+            "description": event.description,
+            "start_time": event.start_time.isoformat(),
+            "end_time": event.end_time.isoformat(),
+            "location": event.location,
+            "is_recurring": event.is_recurring,
+            "recurrence_pattern": event.recurrence_pattern,
+            "owner_id": str(event.owner_id),
+        }
+        history = History(
+            event_id=event_id,
+            version=next_version,
+            data=current_snapshot,
+            timestamp=datetime.utcnow(),
+            changed_by=user_id,
+        )
+        db.add(history)
+
+        await db.commit()
+
+        # !! ГЛАВНОЕ: Загрузить event со всеми нужными связями для сериализации
+        stmt = (
+            select(Event)
+            .options(selectinload(Event.permissions))
+            .where(Event.id == event_id)
+        )
+        result = await db.execute(stmt)
+        event = result.scalars().first()
+        if not event:
+            raise NotFoundError("Event not found after rollback")
+
+        logger.info(
+            "Rolled back event %s to version %s by user %s",
+            event_id,
+            version_id,
+            user_id,
+        )
+        audit_logger.info(
+            "Event rollback: event_id=%s to version=%s by user=%s",
+            event_id,
+            version_id,
+            user_id,
+        )
+
+        return event
+
+    except Exception as exc:
+        await db.rollback()
+        logger.error(
+            "Error rolling back event %s to version %s: %s",
+            event_id,
+            version_id,
+            exc,
+            exc_info=True,
+        )
+        raise ServiceUnavailableError("Database temporarily unavailable")
+
+
+async def get_diff_between_versions(
+    db: AsyncSession, version_id1: UUID, version_id2: UUID
+):
+    """
+    Compute a JSON diff between two event history versions.
+    """
+    try:
+        v1 = await get_event_version(db, version_id1)
+        v2 = await get_event_version(db, version_id2)
+        if not v1 or not v2:
+            logger.warning(
+                "Diff failed: version(s) %s or %s not found", version_id1, version_id2
+            )
+            raise NotFoundError("Version not found")
+
+        diff = jsondiff.diff(v1.data, v2.data)
+        logger.debug(
+            "Computed diff between versions %s and %s", version_id1, version_id2
+        )
+        return diff
+    except Exception as exc:
+        logger.error(
+            "Error computing diff between versions %s and %s: %s",
+            version_id1,
+            version_id2,
+            exc,
+            exc_info=True,
+        )
+        raise ServiceUnavailableError("Database temporarily unavailable")

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ httpx==0.28.1
 identify==2.6.10
 idna==3.10
 iniconfig==2.1.0
+jsondiff==2.2.1
 limits==5.2.0
 Mako==1.3.10
 MarkupSafe==3.0.2


### PR DESCRIPTION
## Summary

- Added `jsondiff` dependency to requirements.txt to support version comparison for event history.
- Implemented endpoints and service logic for event history versioning:
  - Saving event snapshots on changes (create, update, rollback).
  - Retrieving historical versions of an event.
  - Rolling back an event to a specific history version.
  - Computing diffs between two history versions using jsondiff.

## Details

- Updated models, services, and schemas to support history tracking and attribution (user, timestamp).
- Added API endpoints for viewing event history, retrieving specific versions, rolling back, and computing diffs.
- Ensured that history is properly created on every event modification.
- Improved logging for auditability.
- Updated requirements.txt to include jsondiff.